### PR TITLE
Fix 3 crashes

### DIFF
--- a/src/cvmask.py
+++ b/src/cvmask.py
@@ -250,7 +250,10 @@ class CVMask():
         #get coordinates of conflicting pixels
         masks = self.masks
         conf_r,conf_c = np.where(masks.sum(2)>1)
-
+        
+        if len(conf_r) < 1: # no conflicts
+            return
+        
         #centroids of each mask
         centroids = self.centroids
         cen = np.array(centroids)

--- a/src/cvmodel.py
+++ b/src/cvmodel.py
@@ -2502,7 +2502,7 @@ class MaskRCNN():
             full_mask = utils.unmold_mask(masks[i], boxes[i], original_image_shape)
             full_masks.append(full_mask)
         full_masks = np.stack(full_masks, axis=-1)\
-            if full_masks else np.empty(original_image_shape[:2] + (0,))
+            if full_masks else np.empty(original_image_shape[:2] + (0,), dtype=np.bool)
 
         return boxes, class_ids, scores, full_masks
 

--- a/src/cvstitch.py
+++ b/src/cvstitch.py
@@ -128,5 +128,5 @@ class CVMaskStitcher():
             plane_mask = np.max(np.arange(1,n_masks+1, dtype=np.uint16)[None,None,:]*masks, axis=2).flatten()
         np.add.at(channel_counts, plane_mask, 1)
         keep_indices = np.where(channel_counts[1:] > self.threshold)
-        return masks[:, :, keep_indices].squeeze()
+        return masks[:, :, keep_indices].reshape(masks.shape[0:2] + (-1,))
 


### PR DESCRIPTION
Fixes crashes when masks have no conflicts, when there are no cells in a tile, and when there is a single cell in a tile.